### PR TITLE
Fix compilation error.

### DIFF
--- a/src/metaSMT/result_wrapper.hpp
+++ b/src/metaSMT/result_wrapper.hpp
@@ -44,7 +44,7 @@ namespace metaSMT {
       result_type operator() ( std::vector<bool> const & vb) const {
         result_type ret (vb.size());
         for (unsigned i = 0; i < vb.size(); ++i) {
-          ret[i] = vb[i];
+          ret[i] = static_cast<bool>(vb[i]);
         }
         return ret;
       }


### PR DESCRIPTION
src/metaSMT/result_wrapper.hpp:47:18: error: no viable overloaded '='
          ret[i] = vb[i];
          ~~~~~~ ^ ~~~~~

Closes https://github.com/agra-uni-bremen/metaSMT/issues/42