### PR TITLE
Work-around compilation failures with recent clang/boost.

### DIFF
--- a/src/metaSMT/result_wrapper.hpp
+++ b/src/metaSMT/result_wrapper.hpp
@@ -3,6 +3,7 @@
 #include <boost/mpl/vector.hpp>
 #include <boost/variant.hpp>
 #include <boost/logic/tribool.hpp>
+#include <boost/logic/tribool_io.hpp>
 #include <boost/dynamic_bitset.hpp>
 #include <boost/type_traits/is_signed.hpp>
 #include <boost/optional.hpp>
@@ -16,14 +17,14 @@
 #pragma warning (disable : 4146)
 
 namespace metaSMT {
-  /** 
+  /**
    * return value wrapper
    *
-   */ 
+   */
   class result_wrapper {
 
     // converter types
-    struct as_vector_tribool 
+    struct as_vector_tribool
     {
       typedef std::vector<boost::logic::tribool > result_type;
 
@@ -54,9 +55,9 @@ namespace metaSMT {
         result_type ret(size);
         for (unsigned i = 0; i < size; ++i) {
           switch(s[size-i-1]){
-            case '0': 
+            case '0':
               ret[i] = false; break;
-            case '1': 
+            case '1':
               ret[i] = true; break;
             default:
               ret[i] = boost::logic::indeterminate;
@@ -66,7 +67,7 @@ namespace metaSMT {
       }
     };
 
-    struct as_tribool 
+    struct as_tribool
     {
       typedef boost::logic::tribool result_type;
 
@@ -97,9 +98,9 @@ namespace metaSMT {
         boost::logic::tribool ret = false;
         for (unsigned i = 0; i < s.size(); ++i) {
         switch(s[i]){
-          case '0': 
+          case '0':
             break;
-          case '1': 
+          case '1':
             return true;
           default:
             ret = boost::logic::indeterminate;
@@ -117,9 +118,9 @@ namespace metaSMT {
       result_type operator() ( result_type const & v ) const
       { return v; }
 
-      result_type operator() ( boost::logic::tribool t) {
+      result_type operator() ( boost::logic::tribool t) const {
         result_type ret(1);
-        ret[0] = t;
+        ret[0] = static_cast<bool>(t);
         return ret;
       }
 
@@ -132,7 +133,7 @@ namespace metaSMT {
       result_type operator() ( std::vector< boost::logic::tribool > vt ) const {
         result_type ret(vt.size());
         for (unsigned i = 0; i < vt.size(); ++i)
-         ret[i] = vt[i];
+         ret[i] = static_cast<bool>(vt[i]);
         return ret;
       }
 
@@ -146,7 +147,7 @@ namespace metaSMT {
 
     struct as_string
     {
-      typedef std::string result_type; 
+      typedef std::string result_type;
 
       result_type operator() ( result_type const & v ) const {
         return v;
@@ -189,7 +190,7 @@ namespace metaSMT {
 
     struct check_if_X
     {
-      typedef bool result_type; 
+      typedef bool result_type;
 
       template<typename T>
       result_type operator() ( T const & ) const {
@@ -199,7 +200,7 @@ namespace metaSMT {
       result_type operator() ( boost::logic::tribool val ) const {
         return boost::logic::indeterminate(val);
       }
-        
+
       result_type operator() ( std::vector< boost::logic::tribool > val ) const {
         unsigned size = val.size();
         for (unsigned i = 0; i < size; ++i) {
@@ -236,9 +237,9 @@ namespace metaSMT {
       result_wrapper( bool b ) : r (boost::logic::tribool(b)) { }
       result_wrapper( std::string const & s ) : r (boost::algorithm::to_upper_copy(s)) { }
       result_wrapper( const char* s ) : r(boost::algorithm::to_upper_copy(std::string(s))) { }
-      result_wrapper( const char c ) 
-      : r (c=='1' ? boost::logic::tribool(true) 
-        : (c=='0' ? boost::logic::tribool(false) 
+      result_wrapper( const char c )
+      : r (c=='1' ? boost::logic::tribool(true)
+        : (c=='0' ? boost::logic::tribool(false)
         : boost::logic::tribool(boost::logic::indeterminate))
         )
       { }
@@ -304,7 +305,7 @@ namespace metaSMT {
        * The result of this operator might thus be different from the compiler's behavior as a signed
        * downcast is implementation-defined.
        */
-      template< typename Integer> 
+      template< typename Integer>
       operator Integer () const {
         Integer ret = 0;
         std::string val = *this;
@@ -333,7 +334,7 @@ namespace metaSMT {
         if (b) return true;
         else if (!b) return false;
         else return _rng && random_bit();
-      } 
+      }
 
       operator boost::logic::tribool () const {
         return boost::apply_visitor(as_tribool(), r);
@@ -351,7 +352,7 @@ namespace metaSMT {
     result_type r;
     Rng _rng;
   };
-  
+
 } // namespace metaSMT
 
 //  vim: ft=cpp:ts=2:sw=2:expandtab

--- a/tests/test_result_wrapper.cpp
+++ b/tests/test_result_wrapper.cpp
@@ -68,7 +68,7 @@ void check_conversion_XXX( result_wrapper const & rw)
 void check_conversion_0_in_8bit( result_wrapper const & rw)
 {
   tribool tri = rw;
-  BOOST_REQUIRE_EQUAL( tri, false);
+  BOOST_REQUIRE_EQUAL( static_cast<bool>(tri), false);
 
   bool boolean = rw;
   BOOST_REQUIRE_EQUAL( boolean, false);
@@ -106,7 +106,7 @@ void check_conversion_0_in_8bit( result_wrapper const & rw)
 void check_conversion_1_in_8bit( result_wrapper const & rw)
 {
   tribool tri = rw;
-  BOOST_REQUIRE_EQUAL( tri, true);
+  BOOST_REQUIRE_EQUAL( static_cast<bool>(tri), true);
 
   bool boolean = rw;
   BOOST_REQUIRE_EQUAL( boolean, true);
@@ -145,7 +145,7 @@ void check_conversion_1_in_8bit( result_wrapper const & rw)
 void check_conversion_128_in_8bit( result_wrapper const & rw)
 {
   tribool tri = rw;
-  BOOST_REQUIRE_EQUAL( tri, true);
+  BOOST_REQUIRE_EQUAL( static_cast<bool>(tri), true);
 
   bool boolean = rw;
   BOOST_REQUIRE_EQUAL( boolean, true);
@@ -208,7 +208,7 @@ void check_conversion_from_integer(Integer value) {
 
   tribool tri = rw;
   // only check if value is not truncated
-  if (std::numeric_limits<Integer>::digits <= width) BOOST_REQUIRE_EQUAL( tri, true );
+  if (std::numeric_limits<Integer>::digits <= width) BOOST_REQUIRE_EQUAL( static_cast<bool>(tri), true );
 
   bool boolean = rw;
   // only check if value is not truncated
@@ -237,7 +237,7 @@ void check_conversion_from_integer(Integer value) {
 void check_conversion_13_in_8bit( result_wrapper const & rw)
 {
   tribool tri = rw;
-  BOOST_REQUIRE_EQUAL( tri, true);
+  BOOST_REQUIRE_EQUAL( static_cast<bool>(tri), true);
 
   bool boolean = rw;
   BOOST_REQUIRE_EQUAL( boolean, true);
@@ -280,7 +280,7 @@ void check_conversion_true( result_wrapper const & rw)
   using boost::logic::tribool;
 
   tribool tri = rw;
-  BOOST_REQUIRE_EQUAL( tri, true);
+  BOOST_REQUIRE_EQUAL( static_cast<bool>(tri), true);
 
   bool boolean = rw;
   BOOST_REQUIRE_EQUAL( boolean, true);
@@ -319,7 +319,7 @@ void check_conversion_false( result_wrapper const & rw)
   using boost::logic::tribool;
 
   tribool tri = rw;
-  BOOST_REQUIRE_EQUAL( tri, false);
+  BOOST_REQUIRE_EQUAL( static_cast<bool>(tri), false);
 
   bool boolean = rw;
   BOOST_REQUIRE_EQUAL( boolean, false);
@@ -394,10 +394,10 @@ BOOST_AUTO_TEST_CASE( tribool_from_string )
 {
   boost::logic::tribool t;
   t = result_wrapper ("1");
-  BOOST_REQUIRE_EQUAL(t, true);
+  BOOST_REQUIRE_EQUAL(static_cast<bool>(t), true);
 
   t = result_wrapper ("0");
-  BOOST_REQUIRE_EQUAL(t, false);
+  BOOST_REQUIRE_EQUAL(static_cast<bool>(t), false);
 
 	t = result_wrapper ("X");
   BOOST_REQUIRE(boost::logic::indeterminate(t));
@@ -409,10 +409,10 @@ BOOST_AUTO_TEST_CASE( tribool_from_char )
 {
   boost::logic::tribool t;
   t = result_wrapper ('1');
-  BOOST_REQUIRE_EQUAL(t, true);
+  BOOST_REQUIRE_EQUAL(static_cast<bool>(t), true);
 
   t = result_wrapper ('0');
-  BOOST_REQUIRE_EQUAL(t, false);
+  BOOST_REQUIRE_EQUAL(static_cast<bool>(t), false);
 
 	t = result_wrapper ('X');
   BOOST_REQUIRE(boost::logic::indeterminate(t));
@@ -524,7 +524,7 @@ BOOST_AUTO_TEST_CASE( from_vector_tribool )
   vec[0]=false;
   vec[7]=true;
   check_conversion_128_in_8bit( result_wrapper(vec) );
-  
+
   // check for 13 in 8bit
   vec[0]=true;
   vec[2]=true;


### PR DESCRIPTION
This makes MetaSMT successfully compile on FreeBSD.

I'm not sure if these are a correct fixes for the problem.

Let me know if you don't like whitespace changes and I'll remove them (these are automatically inserted by my text editor).